### PR TITLE
give more time for VM instances to be created

### DIFF
--- a/civo/terraform/modules/kubernetes-vms/instance.tf
+++ b/civo/terraform/modules/kubernetes-vms/instance.tf
@@ -18,4 +18,7 @@ resource "civo_instance" "this" {
   script             = var.script
   sshkey_id          = civo_ssh_key.this.id
   region             = var.civo_region
+  timeouts {
+    create = "5m"
+  }
 }


### PR DESCRIPTION
VM often take more than the default timeout to be created on Civo depending on the region and other factors.