### PR TITLE
automatically add entries for the new VMs in SSH config

### DIFF
--- a/civo/examples/terraform/kubernetes-vms/main.tf
+++ b/civo/examples/terraform/kubernetes-vms/main.tf
@@ -49,6 +49,14 @@ resource "null_resource" "sleep" {
   }
 }
 
+resource "null_resource" "update_local_ssh" {
+  depends_on = [ null_resource.sleep ]
+
+ provisioner "local-exec" {
+    command = "/bin/bash ./scripts/update-local-ssh.sh"
+  }
+}
+
 resource "null_resource" "update_etc_hosts" {
   depends_on = [ null_resource.sleep ]
 

--- a/civo/examples/terraform/kubernetes-vms/scripts/update-local-ssh.sh
+++ b/civo/examples/terraform/kubernetes-vms/scripts/update-local-ssh.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+echo "Add hosts in SSH config file (FRED)"
+
+vm_1_public_ip=$(terraform output -json | jq -r '.kubernetes_vms_1_public_ip.value')
+vm_2_public_ip=$(terraform output -json | jq -r '.kubernetes_vms_2_public_ip.value')
+vm_3_public_ip=$(terraform output -json | jq -r '.kubernetes_vms_3_public_ip.value')
+
+echo "
+Host ${vm_1_public_ip}
+Host ${vm_2_public_ip}
+Host ${vm_3_public_ip}
+  User root
+  IdentityFile ${TF_VAR_ssh_private_key_path}
+  IdentitiesOnly yes" >> ~/.ssh/config


### PR DESCRIPTION
It will prevent 'too many authentifications failures' for users that have multiple keys (usually done for security purpose, one key per access). It shouldn't give any issues to those who use just one key.