### PR TITLE
pin the Civo Terraform provider version

### DIFF
--- a/civo/examples/terraform/kubernetes-vms/main.tf
+++ b/civo/examples/terraform/kubernetes-vms/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     civo = {
       source = "civo/civo"
+      version = "1.0.45"
     }
   }
 }


### PR DESCRIPTION
Best practice to pin versions of anything we are using.